### PR TITLE
Adding globbing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are two tasks available
 webpack: {
   someName: {
 	// webpack options
-	entry: "./client/lib/index.js",
+	entry: "./client/lib/index.js", // you may use grunt's templating <%= project.src %>/index.js
 	output: {
 		path: "asserts/",
 		filename: "[hash].js",

--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -118,7 +118,7 @@ class OptionHelper {
 
     if (_.isString(paths)) {
       if (_.startsWith(paths, '.') || _.startsWith(paths, '/')) {
-        result = this.grunt.file.expand({ cwd: process.cwd() }, paths);
+        result = this.grunt.file.expand({}, paths);
 
         // Since the path to the file doesn't require an extension, the above will likely not find any files mataching
         // the pattern if that is the case. In such a scenario, we'll just do any template string replacements and

--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -119,19 +119,24 @@ class OptionHelper {
     if (_.isString(paths)) {
       if (_.startsWith(paths, '.') || _.startsWith(paths, '/')) {
         result = this.grunt.file.expand({ cwd: process.cwd() }, paths);
+
+        // Since the path to the file doesn't require an extension, the above will likely not find any files mataching
+        // the pattern if that is the case. In such a scenario, we'll just do any template string replacements and
+        // return as is.
         if (!result || result.length < 1) {
           result = this.grunt.template.process(paths);
         }
-        if (result && (result.length === 1)) {
+
+        // If the result is an array of only 1 item, we'll just return that first item rather than the array
+        if (_.isArray(result) && (result.length === 1)) {
           result = result[0];
         }
       }
     } else if (Array.isArray(paths)) {
+      // Flatten the array because an array of array of paths is not a valid type of configuration
       result = _.flatten(_.map(paths, (path) => {
         return this.expandPath(path);
       }));
-
-      this.grunt.log.write(JSON.stringify(result));
     } else if (_.isObject(paths)) {
       _.each(paths, (path, key) => {
         result[key] = this.expandPath(path);

--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -128,7 +128,7 @@ class OptionHelper {
         }
 
         // If the result is an array of only 1 item, we'll just return that first item rather than the array
-        if (_.isArray(result) && (result.length === 1)) {
+        if (Array.isArray(result) && (result.length === 1)) {
           result = result[0];
         }
       }

--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -102,7 +102,7 @@ class OptionHelper {
 
   resolvePaths(obj) {
     // Use grunt to expand the path of the following properties
-    const props = ['entry', 'output.path', 'output.filename'];
+    const props = ['entry'];
 
     _.each(props, (prop) => {
       if (_.has(obj, prop)) {
@@ -127,9 +127,11 @@ class OptionHelper {
         }
       }
     } else if (Array.isArray(paths)) {
-      result = _.map(paths, (path) => {
+      result = _.flatten(_.map(paths, (path) => {
         return this.expandPath(path);
-      });
+      }));
+
+      this.grunt.log.write(JSON.stringify(result));
     } else if (_.isObject(paths)) {
       _.each(paths, (path, key) => {
         result[key] = this.expandPath(path);

--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -102,7 +102,7 @@ class OptionHelper {
 
   resolvePaths(obj) {
     // Use grunt to expand the path of the following properties
-    const props = ['entry', 'output.path', 'filename'];
+    const props = ['entry', 'output.path', 'output.filename'];
 
     _.each(props, (prop) => {
       if (_.has(obj, prop)) {

--- a/tests/fixtures/webpack/globbing-files-as-array/Gruntfile.js
+++ b/tests/fixtures/webpack/globbing-files-as-array/Gruntfile.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const webpack = require('webpack');
+const loadGruntWebpackTasks = require('../../../utils/loadGruntWebpackTasks');
+
+module.exports = function (grunt) {
+  const messagesDir = path.join(__dirname, 'messages');
+
+  grunt.initConfig({
+    webpack: {
+      test: {
+        entry: [
+          // Combining globbing support with exact path
+          '<%= globbingFilesTest.messages %>/*.js',
+          path.join(messagesDir, 'welcome.txt')
+        ],
+        output: {
+          path: __dirname,
+          filename: "output.js",
+        }
+      }
+    }
+  });
+
+  grunt.config.set('globbingFilesTest.messages', messagesDir);
+
+  loadGruntWebpackTasks(grunt);
+};

--- a/tests/fixtures/webpack/globbing-files-as-array/exec.js
+++ b/tests/fixtures/webpack/globbing-files-as-array/exec.js
@@ -1,0 +1,6 @@
+assertGrunt.success();
+
+const content = fs.readFileSync(path.join(cwd, 'output.js'), 'utf-8');
+t.regex(content, /Hello/);
+t.regex(content, /World/);
+t.regex(content, /Welcome/);

--- a/tests/fixtures/webpack/globbing-files-as-array/messages/hello.js
+++ b/tests/fixtures/webpack/globbing-files-as-array/messages/hello.js
@@ -1,0 +1,1 @@
+export default 'Hello';

--- a/tests/fixtures/webpack/globbing-files-as-array/messages/welcome.txt
+++ b/tests/fixtures/webpack/globbing-files-as-array/messages/welcome.txt
@@ -1,0 +1,1 @@
+Welcome

--- a/tests/fixtures/webpack/globbing-files-as-array/messages/world.js
+++ b/tests/fixtures/webpack/globbing-files-as-array/messages/world.js
@@ -1,0 +1,1 @@
+export default 'World';

--- a/tests/fixtures/webpack/globbing-files-as-object/Gruntfile.js
+++ b/tests/fixtures/webpack/globbing-files-as-object/Gruntfile.js
@@ -1,0 +1,25 @@
+const path = require('path');
+const webpack = require('webpack');
+const loadGruntWebpackTasks = require('../../../utils/loadGruntWebpackTasks');
+
+module.exports = function (grunt) {
+  grunt.initConfig({
+    webpack: {
+      test: {
+        // Should work when this is an object too
+        entry: {
+            h: '<%= globbingFilesTest.messages %>/h*.js',
+            w: '<%= globbingFilesTest.messages %>/w*.js'
+        },
+        output: {
+          path: __dirname,
+          filename: "output-[name].js",
+        }
+      }
+    }
+  });
+
+  grunt.config.set('globbingFilesTest.messages', path.join(__dirname, 'messages'));
+
+  loadGruntWebpackTasks(grunt);
+};

--- a/tests/fixtures/webpack/globbing-files-as-object/exec.js
+++ b/tests/fixtures/webpack/globbing-files-as-object/exec.js
@@ -1,0 +1,9 @@
+assertGrunt.success();
+
+const content1 = fs.readFileSync(path.join(cwd, 'output-h.js'), 'utf-8');
+t.regex(content1, /Hello/);
+t.regex(content1, /Hi/);
+
+const content2 = fs.readFileSync(path.join(cwd, 'output-w.js'), 'utf-8');
+t.regex(content2, /World/);
+t.regex(content2, /Washington/);

--- a/tests/fixtures/webpack/globbing-files-as-object/messages/hello.js
+++ b/tests/fixtures/webpack/globbing-files-as-object/messages/hello.js
@@ -1,0 +1,1 @@
+export default 'Hello';

--- a/tests/fixtures/webpack/globbing-files-as-object/messages/hi.js
+++ b/tests/fixtures/webpack/globbing-files-as-object/messages/hi.js
@@ -1,0 +1,1 @@
+export default 'Hi';

--- a/tests/fixtures/webpack/globbing-files-as-object/messages/washington.js
+++ b/tests/fixtures/webpack/globbing-files-as-object/messages/washington.js
@@ -1,0 +1,1 @@
+export default 'Washington';

--- a/tests/fixtures/webpack/globbing-files-as-object/messages/world.js
+++ b/tests/fixtures/webpack/globbing-files-as-object/messages/world.js
@@ -1,0 +1,1 @@
+export default 'World';

--- a/tests/fixtures/webpack/globbing-files-as-string/Gruntfile.js
+++ b/tests/fixtures/webpack/globbing-files-as-string/Gruntfile.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const webpack = require('webpack');
+const loadGruntWebpackTasks = require('../../../utils/loadGruntWebpackTasks');
+
+module.exports = function (grunt) {
+  grunt.initConfig({
+    webpack: {
+      test: {
+        // Should be able to process the grunt template string and find all files matching pattern
+        entry: '<%= globbingFilesTest.messages %>/*.js',
+        output: {
+          path: __dirname,
+          filename: "output.js",
+        }
+      }
+    }
+  });
+
+  grunt.config.set('globbingFilesTest.messages', path.join(__dirname, 'messages'));
+
+  loadGruntWebpackTasks(grunt);
+};

--- a/tests/fixtures/webpack/globbing-files-as-string/exec.js
+++ b/tests/fixtures/webpack/globbing-files-as-string/exec.js
@@ -1,0 +1,5 @@
+assertGrunt.success();
+
+const content = fs.readFileSync(path.join(cwd, 'output.js'), 'utf-8');
+t.regex(content, /Hello/);
+t.regex(content, /World/);

--- a/tests/fixtures/webpack/globbing-files-as-string/messages/hello.js
+++ b/tests/fixtures/webpack/globbing-files-as-string/messages/hello.js
@@ -1,0 +1,1 @@
+export default 'Hello';

--- a/tests/fixtures/webpack/globbing-files-as-string/messages/world.js
+++ b/tests/fixtures/webpack/globbing-files-as-string/messages/world.js
@@ -1,0 +1,1 @@
+export default 'World';

--- a/tests/fixtures/webpack/globbing-files-without-extension/Gruntfile.js
+++ b/tests/fixtures/webpack/globbing-files-without-extension/Gruntfile.js
@@ -1,0 +1,25 @@
+const path = require('path');
+const webpack = require('webpack');
+const loadGruntWebpackTasks = require('../../../utils/loadGruntWebpackTasks');
+
+module.exports = function (grunt) {
+  grunt.initConfig({
+    webpack: {
+      test: {
+        entry: [
+          // Since extension is not given, files are not expanded but grunt template strings should still be
+          '<%= globbingFilesTest.messages %>/hello',
+          '<%= globbingFilesTest.messages %>/world'
+        ],
+        output: {
+          path: __dirname,
+          filename: "output.js",
+        }
+      }
+    }
+  });
+
+  grunt.config.set('globbingFilesTest.messages', path.join(__dirname, 'messages'));
+
+  loadGruntWebpackTasks(grunt);
+};

--- a/tests/fixtures/webpack/globbing-files-without-extension/exec.js
+++ b/tests/fixtures/webpack/globbing-files-without-extension/exec.js
@@ -1,0 +1,5 @@
+assertGrunt.success();
+
+const content = fs.readFileSync(path.join(cwd, 'output.js'), 'utf-8');
+t.regex(content, /Hello/);
+t.regex(content, /World/);

--- a/tests/fixtures/webpack/globbing-files-without-extension/messages/hello.js
+++ b/tests/fixtures/webpack/globbing-files-without-extension/messages/hello.js
@@ -1,0 +1,1 @@
+export default 'Hello';

--- a/tests/fixtures/webpack/globbing-files-without-extension/messages/world.js
+++ b/tests/fixtures/webpack/globbing-files-without-extension/messages/world.js
@@ -1,0 +1,1 @@
+export default 'World';


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Tests added?      | yes
| Docs updated?     | yes
| Fixed tickets     | NA
| License           | MIT

While Webpack does have globbing support, Grunt do and most users of Grunt relies on that support in one way or another. I have a use case where I can't have the configurations for the entry property when the task run as its value is somewhat dynamic. This PR basically add globbing support for the entry property so that when Webpack builds, it gets the latest list of files rather than what was set during the initial build.
