### PR TITLE
fix multi target

### DIFF
--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -14,6 +14,7 @@ module.exports = (grunt) => {
 
     const targets = cliTarget ? [cliTarget] : Object.keys(grunt.config([this.name]));
     let runningTargetCount = targets.length;
+    let keepalive = false;
 
     targets.forEach((target) => {
       if (target === 'options') return;
@@ -66,13 +67,9 @@ module.exports = (grunt) => {
           }
         }
 
-        if (!opts.keepalive) {
-          runningTargetCount -= 1;
+        keepalive = keepalive || opts.keepalive;
 
-          if (runningTargetCount === 0) {
-            done();
-          }
-        }
+        if (--runningTargetCount === 0 && !keepalive) done();
       };
 
       if (opts.watch) {

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -13,6 +13,8 @@ module.exports = (grunt) => {
     const done = this.async();
 
     const targets = cliTarget ? [cliTarget] : Object.keys(grunt.config([this.name]));
+    let runningTargetCount = targets.length;
+
     targets.forEach((target) => {
       if (target === 'options') return;
 
@@ -64,7 +66,13 @@ module.exports = (grunt) => {
           }
         }
 
-        if (!opts.keepalive) done();
+        if (!opts.keepalive) {
+          runningTargetCount -= 1;
+
+          if (runningTargetCount === 0) {
+            done();
+          }
+        }
       };
 
       if (opts.watch) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | none
| License           | MIT

This is a bug when running `grunt webpack` with multi targets. If we define multi targets for this plugin, then only 1 or 2 of them will run when user calls `grunt webpack`, and the tasks are picked randomly.

This is because this task is defined as a [grunt basic task](https://gruntjs.com/creating-tasks#basic-tasks), but actually it is designed to be used as a [grunt multi tasks](https://gruntjs.com/creating-tasks#multi-tasks). And when we call `grunt webpack` it should handle all targets, but now the code use a global `done` for all targets, any of them finished will cause this task `done`.

The test fail because of [Grunt bug](https://github.com/gruntjs/grunt/issues/1341), I'll work on that fix first.

An example which repro the bug:
```javascript
/* eslint no-process-env: 1, camelcase: 1 */
const path            = require('path');
const _               = require('underscore');
const webpack         = require('webpack');

module.exports = function (grunt) {
  function webpackConfig(dependency) {
    return {
      entry: require.resolve(dependency),
      output: {
        filename: `${dependency}.js`,
        path: path.join(__dirname, 'dist'),
        libraryTarget: 'amd',
      },
      module: {
        rules: [{
          test: () => true,
          use: 'imports-loader?define=>false',
        }],
      },
      externals: [
        ..._.keys(require(`${dependency}/package.json`).dependencies),
        'bluebird',
      ],
      devtool: 'inline-source-map',
      plugins: [
        new webpack.ProvidePlugin({
          Promise: 'bluebird',
        }),
      ],
    };
  }

  grunt.initConfig({
    webpack: {
      cldrjs: webpackConfig('cldrjs'),
      globalize: webpackConfig('globalize'),
      html2canvas: webpackConfig('html2canvas'),
    },
  });

  grunt.loadNpmTasks('grunt-webpack');

  grunt.registerTask('default', [
    'webpack',
  ]);
};

```

