### PR TITLE
Make fixPlugin work for non-objects

### DIFF
--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -71,7 +71,9 @@ class OptionHelper {
 
     // Operate on a copy of the plugin, since the webpack task
     // can be called multiple times for one instance of a plugin
-    const instance = Array.isArray(plugin) ? [] : Object.create(plugin);
+    const instance = Array.isArray(plugin) ? [] :
+      Object.prototype.isPrototypeOf(plugin) ? Object.create(plugin) :
+      plugin;
     Object.keys(plugin).forEach((key) => {
       if (typeof plugin[key] === 'string') {
         instance[key] = this.grunt.config.process(plugin[key]);

--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -71,7 +71,7 @@ class OptionHelper {
 
     // Operate on a copy of the plugin, since the webpack task
     // can be called multiple times for one instance of a plugin
-    const instance = Object.create(plugin);
+    const instance = Array.isArray(plugin) ? [] : Object.create(plugin);
     Object.keys(plugin).forEach((key) => {
       if (typeof plugin[key] === 'string') {
         instance[key] = this.grunt.config.process(plugin[key]);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | #138
| License           | MIT

Details are in #138, but if `fixPlugin` is passed an Array, it will convert the array into an array-like object, which breaks things like `babel-core`, which is expecting an actual array. This keeps the return value of `fixPlugin` as an array if `plugin` was originally an array. It doesn't seem like the existing code does deep copies of `plugin`, so this should be sufficient.
