### PR TITLE
fix multi target for webpack-dev-server task

### DIFF
--- a/tasks/webpack-dev-server.js
+++ b/tasks/webpack-dev-server.js
@@ -35,7 +35,7 @@ module.exports = (grunt) => {
 To fix this problem install webpack-dev-server by doing either
 yarn add webpack-dev-server --dev
 or
-npm install --save-dev webpack-dev-server 
+npm install --save-dev webpack-dev-server
 `);
     });
     return;
@@ -52,6 +52,9 @@ npm install --save-dev webpack-dev-server
     const done = this.async();
 
     const targets = cliTarget ? [cliTarget] : Object.keys(grunt.config([this.name]));
+    let runningTargetCount = targets.length;
+    let keepalive = false;
+
     targets.forEach((target) => {
       if (target === 'options') return;
       const optionHelper = new OptionHelper(grunt, this.name, target);
@@ -72,7 +75,8 @@ npm install --save-dev webpack-dev-server
       (new WebpackDevServer(compiler, optionHelper.getWebpackDevServerOptions())).listen(opts.port, opts.host, () => {
         const uri = createDomain(opts) + (opts.inline !== false || opts.lazy === true ? '/' : '/webpack-dev-server/');
         reportReadiness(uri, opts, grunt);
-        if (!opts.keepalive) done();
+        keepalive = keepalive || opts.keepalive;
+        if (--runningTargetCount === 0 && !keepalive) done();
       });
     });
   });


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | none
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is counterpart of #140 which fix multi target for webpack task. 

This is a bug when running `grunt webpack-dev-server` with multi targets. If we define multi targets for this plugin, then only 1 or 2 of them will run when user calls `grunt webpack-dev-server`, and the tasks are picked randomly.

This is because now the code use a global `done` for all targets, any of them finished will cause this task `done`.