### PR TITLE
Allow webpack 3 as peer, use webpack 3 as devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tasks"
   ],
   "peerDependencies": {
-    "webpack": "^2.1.0-beta || ^2.2.0-rc || 2"
+    "webpack": "^2.1.0-beta || ^2.2.0-rc || 2 || 3"
   },
   "license": "MIT",
   "keywords": [
@@ -44,7 +44,7 @@
     "glob": "^7.0.5",
     "grunt": "^1.0.0",
     "nyc": "^10.0.0",
-    "webpack": "^2.2.0"
+    "webpack": "^3.0.0"
   },
   "dependencies": {
     "deep-for-each": "^1.0.5",


### PR DESCRIPTION
@sokra @TheLarkInn 

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | None
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

Since Webpack 3 has been released, this package should be updated to allow Webpack 3 as a peer dependency.  Not really necessary, but I've also bumped the `devDependency` on Webpack to 3 as well.

The API between Webpack 2 and 3 seems to be unchanged, so I'm not aware of any differences that would need to be accounted for in this package, it should just be a loosening of the `peerDependency` that's required.