### PR TITLE
Only process plugins directly related to webpack. [Fixes #138]

### DIFF
--- a/src/options/OptionHelper.js
+++ b/src/options/OptionHelper.js
@@ -2,6 +2,13 @@
 const deepForEach = require('deep-for-each');
 const defaults = require('./default');
 
+const PLUGIN_PROPS = [
+  'plugins',
+  'resolve.plugins',
+  'webpack.plugins',
+  'webpack.resolve.plugins'
+];
+
 class OptionHelper {
 
   constructor(grunt, taskName, target) {
@@ -55,10 +62,10 @@ class OptionHelper {
       obj = obj();
     }
 
-    deepForEach(obj, function (value, key, parent) {
+    deepForEach(obj, function (value, key, parent, path) {
       if (typeof value === 'string') {
         parent[key] = this.grunt.config.process(value);
-      } else if (Array.isArray(value) && key === 'plugins') {
+      } else if (PLUGIN_PROPS.indexOf(path) !== -1 && Array.isArray(value)) {
         parent[key] = value.map(plugin => this.fixPlugin(plugin));
       }
     }.bind(this));


### PR DESCRIPTION
…gins

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | #138
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR reverts the previous implementation of `OptionHelper#fixPlugin` function that only crawled `plugins` properties directly related to webpack, not to its loaders.

Fixes a known issue with `babel-loader`.