### PR TITLE
pass `statsOptions` to `stats.toJson`

### DIFF
--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -149,7 +149,7 @@ module.exports = function(grunt) {
         }, statsOptions)));
       }
       if(typeof storeStatsTo === "string") {
-        grunt.config.set(storeStatsTo, stats.toJson());
+        grunt.config.set(storeStatsTo, stats.toJson(statsOptions));
       }
       if(failOnError && stats.hasErrors()) {
         return done(false);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | stats
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

pass `statsOptions` to `stats.toJson` so that output `stats.json` with control.