### PR TITLE
Read watchOptions using optionsHelper

### DIFF
--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -25,6 +25,7 @@ module.exports = (grunt) => {
       const optionHelper = new OptionHelper(grunt, this.name, target);
 
       const watch = optionHelper.get('watch');
+      const watchOptions = optionHelper.get('watchOptions');
       const opts = {
         cache: watch ? false : optionHelper.get('cache'),
         failOnError: optionHelper.get('failOnError'),
@@ -76,7 +77,7 @@ module.exports = (grunt) => {
       };
 
       if (opts.watch) {
-        compiler.watch(webpackOptions.watchOptions || {}, handler);
+        compiler.watch(watchOptions || {}, handler);
       } else {
         compiler.run(handler);
       }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | 
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

`webpackOptions.watchOptions` is always undefined. Read `watchOptions` using optionsHelper and pass it to webpack compiler.