### PR TITLE
Fix duplicated entry of HotModuleReplacementPlugin, when using webpack-dev-server >= 3.2.0

### DIFF
--- a/tasks/webpack-dev-server.js
+++ b/tasks/webpack-dev-server.js
@@ -116,11 +116,6 @@ npm install --save-dev webpack-dev-server
 
         WebpackDevServer.addDevServerEntrypoints(webpackOptions, opts);
 
-        if (opts.inline && (opts.hotOnly || opts.hot)) {
-          webpackOptions.plugins = webpackOptions.plugins || [];
-          webpackOptions.plugins.push(new webpack.HotModuleReplacementPlugin());
-        }
-
         const compiler = webpack(webpackOptions);
 
         if (opts.progress)


### PR DESCRIPTION


| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Tests added?      | no
| Docs updated?     | no
| Fixed tickets     | #172 
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->
